### PR TITLE
Increased MTU to 1500.

### DIFF
--- a/sal-stack-nanostack-slip/Slip.h
+++ b/sal-stack-nanostack-slip/Slip.h
@@ -25,7 +25,7 @@ typedef enum
     SLIP_RX_STATE_ESCAPED
 } slip_rx_state_t;
 
-#define SLIP_TX_RX_MAX_BUFLEN 1280 // SLIP MTU
+#define SLIP_TX_RX_MAX_BUFLEN 1500 // SLIP MTU
 #define SLIP_NR_BUFFERS 20
 
 #define SLIP_END 0xC0


### PR DESCRIPTION
@devran01 Increased MTU size to 1500 as the latest nanostack and Linux (e.g. OpenWRT) supports dynamic path MTU discovery on TUN interfaces and on point-to-point interfaces, respectively.
