### PR TITLE
Enable hardware flow control on Serial device used for backhaul

### DIFF
--- a/sal-stack-nanostack-slip/Slip.h
+++ b/sal-stack-nanostack-slip/Slip.h
@@ -42,9 +42,9 @@ struct SlipBuffer {
 
 class SlipMACDriver : public RawSerial {
 public:
-    SlipMACDriver(PinName tx, PinName rx);
+    SlipMACDriver(PinName tx, PinName rx, PinName rts = NC, PinName cts = NC);
     virtual ~SlipMACDriver();
-    int8_t Slip_Init(uint8_t *mac = NULL);
+    int8_t Slip_Init(uint8_t *mac = NULL, uint32_t backhaulBaud = 115200);
     static int8_t slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data_protocol_e data_flow);
     static void slip_rx();
 

--- a/source/Slip.cpp
+++ b/source/Slip.cpp
@@ -25,9 +25,11 @@
 
 static SlipMACDriver *_pslipmacdriver;
 
-SlipMACDriver::SlipMACDriver(PinName tx, PinName rx) : RawSerial(tx, rx)
+SlipMACDriver::SlipMACDriver(PinName tx, PinName rx, PinName rts, PinName cts) : RawSerial(tx, rx)
 {
     _pslipmacdriver = this;
+    if(rts != NC && cts != NC)
+    	set_flow_control(RTSCTS, rts, cts);
     slip_rx_buflen = 0;
     slip_rx_state = SLIP_RX_STATE_SYNCSEARCH;
     memset(slip_mac, 0, sizeof(slip_mac));
@@ -192,7 +194,7 @@ void SlipMACDriver::rxIrq(void)
     }
 }
 
-int8_t SlipMACDriver::Slip_Init(uint8_t *mac)
+int8_t SlipMACDriver::Slip_Init(uint8_t *mac, uint32_t backhaulBaud)
 {
     SlipBuffer *pTmpSlipBuffer;
 
@@ -236,7 +238,7 @@ int8_t SlipMACDriver::Slip_Init(uint8_t *mac)
         pTxSlipBufferFreeList.push(pTmpSlipBuffer);
     }
 
-    baud(115200);
+    baud(backhaulBaud);
 
     attach(this, &SlipMACDriver::rxIrq, RxIrq);
     return net_slip_id;


### PR DESCRIPTION
**DO NOT MERGE**: The features added in this PR need changes in other components.

- Add support for Hardware flow control
- Configurable backhaul serial device baud rate

@SeppoTakalo @jpellikk-arm 
Please review