### PR TITLE
[ONME-2688] RTOS Integration for SLIP

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,10 @@
+{
+	"name": "slip",
+	"config": {
+		"pins_LED1": "NC",
+		"pins_SERIAL_TX": "NC",
+      	"pins_SERIAL_RX": "NC",
+      	"pins_SERIAL_CTS": "NC",
+      	"pins_SERIAL_RTS": "NC"
+	}
+}

--- a/sal-stack-nanostack-slip/Slip.h
+++ b/sal-stack-nanostack-slip/Slip.h
@@ -18,6 +18,26 @@
 #define SLIP_H
 
 #include "nanostack/platform/arm_hal_phy.h"
+#include "eventOS_event.h"
+#include "net_interface.h"
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "CircularBuffer.h"
+#ifdef MBED_CONF_APP_LED1
+#define LED1  MBED_CONF_APP_LED1
+#endif
+#ifdef MBED_CONF_APP_SERIAL_TX
+#define SERIAL_TX  MBED_CONF_APP_SERIAL_TX
+#endif
+#ifdef MBED_CONF_APP_SERIAL_RX
+#define SERIAL_RX  MBED_CONF_APP_SERIAL_RX
+#endif
+#ifdef MBED_CONF_APP_SERIAL_CTS
+#define SERIAL_CTS  MBED_CONF_APP_SERIAL_CTS
+#endif
+#ifdef MBED_CONF_APP_SERIAL_RTS
+#define SERIAL_RTS  MBED_CONF_APP_SERIAL_RTS
+#endif
+#endif
 
 typedef enum {
     SLIP_RX_STATE_SYNCSEARCH,
@@ -25,19 +45,37 @@ typedef enum {
     SLIP_RX_STATE_ESCAPED
 } slip_rx_state_t;
 
+typedef enum {
+    SLIP_TX_STATE_START,
+    SLIP_TX_STATE_RUNNING,
+    SLIP_TX_STATE_ESCAPING,
+    SLIP_TX_STATE_END
+} slip_tx_state_t;
+
+typedef enum {
+    TX_Interrupt,
+    RX_Interrupt
+} slip_IRQ_type;
+
 #define SLIP_MTU 1500
-#define SLIP_TX_RX_MAX_BUFLEN (1+SLIP_MTU*2+1) // End, every byte escaped, End (!)
-#define SLIP_NR_BUFFERS 20
+#define SLIP_TX_RX_MAX_BUFLEN SLIP_MTU
+#define SLIP_NR_TX_BUFFERS 8
+#ifdef MBED_CONF_RTOS_PRESENT
+#define SLIP_NR_RX_BUFFERS 4
+#else
+#define SLIP_NR_RX_BUFFERS 1
+#endif
 
 #define SLIP_END 0xC0
 #define SLIP_ESC 0xDB
 #define SLIP_ESC_END 0xDC
 #define SLIP_ESC_ESC 0xDD
+#define SLIP_PACKET_RX 5
 
 struct SlipBuffer {
     SlipBuffer(size_t length = 0): length(length) {}
     uint8_t buf[SLIP_TX_RX_MAX_BUFLEN];
-    int length;
+    size_t length;
 };
 
 class SlipMACDriver : public RawSerial {
@@ -47,20 +85,30 @@ public:
     int8_t Slip_Init(uint8_t *mac = NULL, uint32_t backhaulBaud = 115200);
     static int8_t slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data_protocol_e data_flow);
     static void slip_rx();
+    void buffer_handover();
 
 private:
     // Interrupt routines for UART rx/tx interrupts
     void rxIrq(void);
     void txIrq(void);
     void process_rx_byte(uint8_t character);
+    bool tx_one_byte();
+    void slip_if_rx(const SlipBuffer *rx_buf) const;
     static void print_serial_error();
-    uint8_t slip_rx_buf[SLIP_TX_RX_MAX_BUFLEN];
-    uint16_t slip_rx_buflen;
+#ifdef MBED_CONF_RTOS_PRESENT
+    void slip_if_interrupt_handler(slip_IRQ_type type);
+    void SLIP_IRQ_Thread_Create(void);
+#endif
+    SlipBuffer *pCurSlipRxBuffer;
+    CircularBuffer<SlipBuffer *, SLIP_NR_RX_BUFFERS> pRxSlipBufferFreeList;
+    CircularBuffer<SlipBuffer *, SLIP_NR_RX_BUFFERS> pRxSlipBufferToRxFuncList;
     slip_rx_state_t slip_rx_state;
     uint8_t slip_mac[6];
     SlipBuffer *pCurSlipTxBuffer;
-    CircularBuffer<SlipBuffer *, SLIP_NR_BUFFERS> pTxSlipBufferFreeList;
-    CircularBuffer<SlipBuffer *, SLIP_NR_BUFFERS> pTxSlipBufferToTxFuncList;
+    size_t slip_tx_count;
+    slip_tx_state_t slip_tx_state;
+    CircularBuffer<SlipBuffer *, SLIP_NR_TX_BUFFERS> pTxSlipBufferFreeList;
+    CircularBuffer<SlipBuffer *, SLIP_NR_TX_BUFFERS> pTxSlipBufferToTxFuncList;
     phy_device_driver_s slip_phy_driver;
     int8_t net_slip_id;
 };

--- a/source/Slip.cpp
+++ b/source/Slip.cpp
@@ -16,23 +16,37 @@
  */
 
 #include "mbed-drivers/mbed.h"
-#include "mbed-client-libservice/platform/arm_hal_interrupt.h"
+#ifndef MBED_CONF_RTOS_PRESENT
 #include "core-util/CriticalSectionLock.h"
+#endif
+#include "mbed-client-libservice/platform/arm_hal_interrupt.h"
 #include "sal-stack-nanostack-slip/Slip.h"
 //#define HAVE_DEBUG 1
 #include "ns_trace.h"
+#ifdef MBED_CONF_RTOS_PRESENT
+#define SIG_SL_TX       1
+#define SIG_SL_RX       2
+#include "cmsis_os.h"
+static osThreadId slip_thread_id;
+static void slip_if_lock(void);
+static void slip_if_unlock(void);
+#endif
+
 #define TRACE_GROUP  "slip"
 
 static SlipMACDriver *_pslipmacdriver;
-
 static phy_device_driver_s *drv;
 
 SlipMACDriver::SlipMACDriver(PinName tx, PinName rx, PinName rts, PinName cts) : RawSerial(tx, rx)
 {
     _pslipmacdriver = this;
-    if(rts != NC && cts != NC)
-        set_flow_control(RTSCTS, rts, cts);
-    slip_rx_buflen = 0;
+#if DEVICE_SERIAL_FC
+    if(rts != NC && cts != NC) {
+       set_flow_control(RTSCTS, rts, cts);
+    }
+#endif
+    pCurSlipRxBuffer = NULL;
+    pCurSlipTxBuffer = NULL;
     slip_rx_state = SLIP_RX_STATE_SYNCSEARCH;
     memset(slip_mac, 0, sizeof(slip_mac));
 }
@@ -46,8 +60,7 @@ SlipMACDriver::~SlipMACDriver()
 int8_t SlipMACDriver::slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data_protocol_e data_flow)
 {
     (void) data_flow;
-    SlipBuffer *pTxBuf = NULL;
-    uint16_t txBuflen = 0;
+    SlipBuffer *pTxBuf;
 
     tr_debug("slip_if_tx(): datalen = %d", len);
 
@@ -57,35 +70,36 @@ int8_t SlipMACDriver::slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data
     }
 
     {
+#ifndef MBED_CONF_RTOS_PRESENT
         mbed::util::CriticalSectionLock lock;
+#else
+        core_util_critical_section_enter();
+#endif
+
         bool bufValid = _pslipmacdriver->pTxSlipBufferFreeList.pop(pTxBuf);
+#ifdef MBED_CONF_RTOS_PRESENT
+        core_util_critical_section_exit();
+#endif
         //TODO: No more free TX buffers??
         if (!bufValid) {
+            tr_error("Ran out of TX Buffers.");
             return 0;
         }
     }
 
-    pTxBuf->buf[txBuflen++] = SLIP_END;
-    while (len--) {
-        if (*buf == SLIP_END) {
-            pTxBuf->buf[txBuflen++] = SLIP_ESC;
-            pTxBuf->buf[txBuflen++] = SLIP_ESC_END;
-            buf++;
-        } else if (*buf == SLIP_ESC) {
-            pTxBuf->buf[txBuflen++] = SLIP_ESC;
-            pTxBuf->buf[txBuflen++] = SLIP_ESC_ESC;
-            buf++;
-        } else {
-            pTxBuf->buf[txBuflen++] = *buf++;
-        }
-    }
-
-    pTxBuf->buf[txBuflen++] = SLIP_END;
-    pTxBuf->length = txBuflen;
+    memcpy(pTxBuf->buf, buf, len);
+    pTxBuf->length = len;
 
     {
+#ifndef MBED_CONF_RTOS_PRESENT
         mbed::util::CriticalSectionLock lock;
+#else
+        core_util_critical_section_enter();
+#endif
         _pslipmacdriver->pTxSlipBufferToTxFuncList.push(pTxBuf);
+#ifdef MBED_CONF_RTOS_PRESENT
+        core_util_critical_section_exit();
+#endif
     }
 
     _pslipmacdriver->attach(_pslipmacdriver, &SlipMACDriver::txIrq, TxIrq);
@@ -100,40 +114,94 @@ int8_t SlipMACDriver::slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data
 
 void SlipMACDriver::txIrq(void)
 {
-    static int i = 0;
-    static SlipBuffer *pTxSlipBuffer = NULL;
-
-    if (!pTxSlipBuffer) {
-        if (!pTxSlipBufferToTxFuncList.pop(pTxSlipBuffer)) {
+    if (!pCurSlipTxBuffer) {
+        if (!pTxSlipBufferToTxFuncList.pop(pCurSlipTxBuffer)) {
             attach(NULL, TxIrq);
             return;
         }
+        slip_tx_count = 0;
+        slip_tx_state = SLIP_TX_STATE_START;
     }
 
-    if (pTxSlipBuffer->buf) {
-        while (writeable()) {
-            _base_putc(pTxSlipBuffer->buf[i++]);
-            if (i == pTxSlipBuffer->length) {
-                i = 0;
-                pTxSlipBufferFreeList.push(pTxSlipBuffer);
-                pTxSlipBuffer = NULL;
-                break;
-            }
+    while (writeable()) {
+        if (!tx_one_byte()) {
+            // Transmit of current buffer finished
+            pTxSlipBufferFreeList.push(pCurSlipTxBuffer);
+            pCurSlipTxBuffer = NULL;
+            break;
         }
     }
+}
+
+// Called when we have a buffer TX in progress, and the serial is writable.
+// Transmits exactly one byte. Returns true if there are more bytes to transmit
+// in the current buffer, false if current buffer is finished.
+bool SlipMACDriver::tx_one_byte(void)
+{
+    uint8_t byte;
+    switch (slip_tx_state) {
+        case SLIP_TX_STATE_START:
+            byte = SLIP_END;
+            slip_tx_state = SLIP_TX_STATE_RUNNING;
+            break;
+        case SLIP_TX_STATE_RUNNING:
+            byte = pCurSlipTxBuffer->buf[slip_tx_count];
+            if (byte == SLIP_END || byte == SLIP_ESC) {
+                byte = SLIP_ESC;
+                slip_tx_state = SLIP_TX_STATE_ESCAPING;
+            } else {
+                slip_tx_count++;
+            }
+            break;
+        case SLIP_TX_STATE_ESCAPING:
+            byte = pCurSlipTxBuffer->buf[slip_tx_count++];
+            switch (byte) {
+                case SLIP_END:
+                    byte = SLIP_ESC_END;
+                    break;
+                case SLIP_ESC:
+                    byte = SLIP_ESC_ESC;
+                    break;
+            }
+            slip_tx_state = SLIP_TX_STATE_RUNNING;
+            break;
+        case SLIP_TX_STATE_END:
+            byte = SLIP_END;
+            break;
+        default:
+            return false;
+    }
+
+    _base_putc(byte);
+
+    if (slip_tx_state == SLIP_TX_STATE_END) {
+        return false;
+    }
+
+    if (slip_tx_count == pCurSlipTxBuffer->length) {
+        slip_tx_state = SLIP_TX_STATE_END;
+    }
+    return true;
 }
 
 void SlipMACDriver::process_rx_byte(uint8_t character)
 {
     if (character == SLIP_END) {
-        if (slip_rx_buflen > 0) {
+        if (pCurSlipRxBuffer && pCurSlipRxBuffer->length > 0) {
+
+#ifndef MBED_CONF_RTOS_PRESENT
             platform_interrupts_disabled();
-            if( slip_phy_driver.phy_rx_cb ){
-                slip_phy_driver.phy_rx_cb(slip_rx_buf, slip_rx_buflen, 0x80, 0, net_slip_id);
-            }
+            slip_if_rx(pCurSlipRxBuffer);
             platform_interrupts_enabling();
+            // can just reuse buffer
+            pCurSlipRxBuffer->length = 0;
+#else
+            pRxSlipBufferToRxFuncList.push(pCurSlipRxBuffer);
+            pCurSlipRxBuffer = NULL;
+            osSignalSet(slip_thread_id, SIG_SL_RX);
+#endif
+
         }
-        slip_rx_buflen = 0;
         slip_rx_state = SLIP_RX_STATE_SYNCED;
         return;
     }
@@ -161,12 +229,20 @@ void SlipMACDriver::process_rx_byte(uint8_t character)
         slip_rx_state = SLIP_RX_STATE_SYNCED;
     }
 
-    if (slip_rx_buflen < sizeof slip_rx_buf) {
-        slip_rx_buf[slip_rx_buflen++] = character;
+    // Reached the point we have a data byte to store. Find buffer now.
+    if (!pCurSlipRxBuffer) {
+        if (!pRxSlipBufferFreeList.pop(pCurSlipRxBuffer)) {
+            slip_rx_state = SLIP_RX_STATE_SYNCSEARCH;
+            return;
+        }
+    }
+
+    if (pCurSlipRxBuffer->length < sizeof(pCurSlipRxBuffer->buf)) {
+        pCurSlipRxBuffer->buf[pCurSlipRxBuffer->length++] = character;
     } else {
         // Buffer overrun - abandon frame
         slip_rx_state = SLIP_RX_STATE_SYNCSEARCH;
-        slip_rx_buflen = 0;
+        pCurSlipRxBuffer->length = 0;
     }
 }
 
@@ -177,13 +253,14 @@ void SlipMACDriver::print_serial_error()
 
 void SlipMACDriver::rxIrq(void)
 {
-    //bool err = error();
     bool err = 0;
-
     if (err && slip_rx_state != SLIP_RX_STATE_SYNCSEARCH) {
         slip_rx_state = SLIP_RX_STATE_SYNCSEARCH;
-        minar::Scheduler::postCallback(mbed::util::FunctionPointer0<void>(print_serial_error).bind())
-        .tolerance(minar::milliseconds(1));
+#ifndef MBED_CONF_RTOS_PRESENT
+        minar::Scheduler::postCallback(
+                mbed::util::FunctionPointer0<void>(print_serial_error).bind()).tolerance(
+                minar::milliseconds(1));
+#endif
     }
 
     while (readable()) {
@@ -196,8 +273,6 @@ void SlipMACDriver::rxIrq(void)
 
 int8_t SlipMACDriver::Slip_Init(uint8_t *mac, uint32_t backhaulBaud)
 {
-    SlipBuffer *pTmpSlipBuffer;
-
     if (mac != NULL) {
         // Assign user submitted MAC value
         for (uint8_t i = 0; i < sizeof(slip_mac); ++i) {
@@ -226,17 +301,87 @@ int8_t SlipMACDriver::Slip_Init(uint8_t *mac, uint32_t backhaulBaud)
     // init rx state machine
     tr_debug("SLIP driver id: %d\r\n", net_slip_id);
 
-    for (int i = 0; i < SLIP_NR_BUFFERS; i++) {
-        pTmpSlipBuffer = new SlipBuffer;
+    for (int i = 0; i < SLIP_NR_TX_BUFFERS; i++) {
+        pTxSlipBufferFreeList.push(new SlipBuffer);
+    }
 
-        memset(pTmpSlipBuffer->buf, 0, sizeof pTmpSlipBuffer->buf);
-        pTmpSlipBuffer->length = 0;
-
-        pTxSlipBufferFreeList.push(pTmpSlipBuffer);
+    for (int i = 0; i < SLIP_NR_RX_BUFFERS; i++) {
+        pRxSlipBufferFreeList.push(new SlipBuffer);
     }
 
     baud(backhaulBaud);
 
     attach(this, &SlipMACDriver::rxIrq, RxIrq);
+
+
+#ifdef MBED_CONF_RTOS_PRESENT
+_pslipmacdriver->SLIP_IRQ_Thread_Create();
+#endif
+
     return net_slip_id;
 }
+
+void SlipMACDriver::slip_if_rx(const SlipBuffer *rx_buf) const
+{
+    if (slip_phy_driver.phy_rx_cb) {
+        slip_phy_driver.phy_rx_cb(rx_buf->buf, rx_buf->length, 0x80, 0, net_slip_id);
+    }
+}
+
+void SlipMACDriver::buffer_handover()
+{
+    for (;;) {
+        SlipBuffer *rx_buf = NULL;
+
+        core_util_critical_section_enter();
+        pRxSlipBufferToRxFuncList.pop(rx_buf);
+        core_util_critical_section_exit();
+
+        if (!rx_buf) {
+            break;
+        }
+
+        slip_if_rx(rx_buf);
+
+        core_util_critical_section_enter();
+        rx_buf->length = 0;
+        pRxSlipBufferFreeList.push(rx_buf);
+        core_util_critical_section_exit();
+    }
+}
+
+#ifdef MBED_CONF_RTOS_PRESENT
+
+static void slip_if_lock(void)
+{
+    platform_enter_critical();
+}
+
+static void slip_if_unlock(void)
+{
+    platform_exit_critical();
+}
+
+static void SLIP_IRQ_Thread(const void *x)
+{
+    for (;;) {
+        osEvent event = osSignalWait(0, osWaitForever);
+        if (event.status != osEventSignal) {
+            continue;
+        }
+        slip_if_lock();
+        if (event.value.signals & SIG_SL_RX) {
+            _pslipmacdriver->buffer_handover();
+        }
+        slip_if_unlock();
+    }
+}
+
+void SlipMACDriver::SLIP_IRQ_Thread_Create(void)
+{
+    static osThreadDef(SLIP_IRQ_Thread, osPriorityAboveNormal, 512);
+    slip_thread_id = osThreadCreate(osThread(SLIP_IRQ_Thread), NULL);
+}
+
+
+#endif


### PR DESCRIPTION
Driver has been modified to support Morpheous.

Major Design Changes:

* No. of buffers are reduced because we can reuse buffers.
  Previously it was taking up 60k of RAM
* No need to allocate 3k of memory for buffer anymore. Buffer size is
  now equal to SLIP MTU, i.e., 1500 bytes. Previously, it needed that much buffer space
  because of escaping inside the buffer.
  Now, escaping is done inside TxIRQ using a seprate state machine, hence saving valuable RAM.
* Nanostack is being called from thread instead of interrupt.
* Redesign of driver keeps the spport for legacy yotta support still.