### PR TITLE
Replace deprecated attach method

### DIFF
--- a/source/Slip.cpp
+++ b/source/Slip.cpp
@@ -88,7 +88,7 @@ int8_t SlipMACDriver::slip_if_tx(uint8_t *buf, uint16_t len, uint8_t tx_id, data
     _pslipmacdriver->pTxSlipBufferToTxFuncList.push(pTxBuf);
     core_util_critical_section_exit();
 
-    _pslipmacdriver->attach(_pslipmacdriver, &SlipMACDriver::txIrq, TxIrq);
+    _pslipmacdriver->attach(callback(_pslipmacdriver, &SlipMACDriver::txIrq), TxIrq);
 
     // success callback
     if( drv->phy_tx_done_cb ){


### PR DESCRIPTION
Replace deprecated mbed::SerialBase::attach(T*, void (T::*)() method
with attach(callback(obj, method), type).